### PR TITLE
Add explicit id="biwa-script" to <script> tag

### DIFF
--- a/repl.html
+++ b/repl.html
@@ -84,7 +84,7 @@
     </td></tr></table>
   </div>
 
-<script type="text/javascript" src="src/development_loader.js">// <![CDATA[
+<script id="biwa-script" type="text/javascript" src="src/development_loader.js">// <![CDATA[
 var biwascheme = new BiwaScheme.Interpreter();
 function bs_eval(){
   $('bs-console').innerHTML = "";

--- a/src/development_loader.js
+++ b/src/development_loader.js
@@ -44,21 +44,14 @@ var BiwaScheme = BiwaScheme || {};
   }
 
   // Find the script tag
-  var find_script_tag = function(e){
-    if(e.nodeName.toLowerCase() == 'script'){
-      return e;
-    }
-    else if(e.id == '_firebugConsole'){
-      if(e.previousSibling.nodeName.toLowerCase() == 'script')
-        return e.previousSibling;
-      else
-        console.error("BiwaScheme could not find the script tag... please use firebug 1.5.0")
-    }
-    else{
-      return find_script_tag(e.lastChild);
-    }
+  var find_script_tag = function(){
+      var tag = document.getElementById("biwa-script");
+      if(tag == null) {
+          console.error("BiwaScheme could not find the script tag...")
+      }
+      return tag;
   };
-  var script = find_script_tag(document);
+  var script = find_script_tag();
 
   var src = readAttribute(script, 'src');
   var dir = src.match(/(.*)src\/development_loader.js/)[1];

--- a/test/browser_test.html
+++ b/test/browser_test.html
@@ -24,7 +24,7 @@ td.dump_stknum{ color:gold; }
 <div id='bs-console'>
 </div>
 
-<script type="text/javascript" src="../src/development_loader.js">
+<script id="biwa-script" type="text/javascript" src="../src/development_loader.js">
 // for browsers   
 var dumper = new BiwaScheme.Dumper();
 BiwaScheme.Interpreter.dumper = dumper;

--- a/test/spec.html
+++ b/test/spec.html
@@ -15,7 +15,7 @@
 
 <script type="text/javascript">// <![CDATA[
 var loader_development = function(proc){
-  document.write("<script src='../src/development_loader.js'>" +
+  document.write("<script id='biwa-script'  src='../src/development_loader.js'>" +
     "BiwaScheme.register_tests();" +
     "JSSpec.start_test();" +
     "<\/script>");

--- a/test/tracer.html
+++ b/test/tracer.html
@@ -25,7 +25,7 @@ td.dump_stknum{ color:gold; }
 <div id='dumparea'>
 </div>
 
-<script type="text/javascript" src="../src/development_loader.js">
+<script id="biwa-script" type="text/javascript" src="../src/development_loader.js">
 // for browsers   
 var dumper = new BiwaScheme.Dumper();
 BiwaScheme.Interpreter.dumper = dumper;


### PR DESCRIPTION
The last pull request got lost by GitHub's meltdown, but it may reappear...

I'm concerned about how development_loader.js looks for its own <script> tag by recursively traversing the DOM.  Notably, this breaks on Chromium 7.0.517.44 (64615) Ubuntu 10.10 (but not Chrome, weirdly) because it traverses into the <style> tag and tries taking nodeName of null.  

Adding an id to the <script> tags lets us use getElementById and also prevents any potential problems with having multiple <script> tags on the page.
