### PR TITLE
Invalid syntax checks

### DIFF
--- a/src/system/compiler.js
+++ b/src/system/compiler.js
@@ -283,6 +283,10 @@ BiwaScheme.Compiler = Class.create({
       else if(x instanceof BiwaScheme.Pair){
         switch(x.first()){
         case BiwaScheme.Sym("define"):
+          // error-checking: should have only 3 things
+          if(x.length() != 3)
+              throw new BiwaScheme.Error("Invalid define: "+x.to_write());
+
           var left = x.cdr.car;
           var exp  = x.cdr.cdr;
           
@@ -317,11 +321,17 @@ BiwaScheme.Compiler = Class.create({
           }
           return c;
         case BiwaScheme.Sym("quote"):
+          if(x.length() < 2)
+              throw new BiwaScheme.Error("Invalid quote: "+x.to_write());
+
           var obj=x.second();
           return ["constant", obj, next];
         case BiwaScheme.Sym("lambda"):
           // x = '(lambda (x y) x y)
           // x = '(lambda vars x y)
+          if(x.length() < 3)
+              throw new BiwaScheme.Error("Invalid lambda: "+x.to_write());
+
           var vars = x.cdr.car;
           var body = new BiwaScheme.Pair(BiwaScheme.Sym("begin"), x.cdr.cdr); //tenuki
 
@@ -342,6 +352,9 @@ BiwaScheme.Compiler = Class.create({
                            dotpos];
           return this.collect_free(free, e, do_close);
         case BiwaScheme.Sym("if"):
+          if(x.length() < 3 || x.length() > 4)
+              throw new BiwaScheme.Error("Invalid if: "+x.to_write());
+
           var testc=x.second(), thenc=x.third(), elsec=x.fourth();
           var thenc = this.compile(thenc, e, s, f, next);
           var elsec = this.compile(elsec, e, s, f, next);
@@ -349,6 +362,10 @@ BiwaScheme.Compiler = Class.create({
           next = ["test", thenc, elsec];
           break;
         case BiwaScheme.Sym("set!"):
+          // error-checking: should have only 3 things
+          if(x.length() != 3)
+              throw new BiwaScheme.Error("Invalid set!: "+x.to_write());
+
           var v=x.second(), x=x.third();
           var do_assign = this.compile_lookup(v, e,
             function(n){ return ["assign-local", n, next]; },

--- a/src/version.js
+++ b/src/version.js
@@ -1,7 +1,7 @@
 var BiwaScheme = BiwaScheme || {};
 
 BiwaScheme.Version = "0.5.4.2";
-BiwaScheme.GitCommit = "127df5097357cb8aa3414039ca4b30233434e27d";
+BiwaScheme.GitCommit = "e73fa7c7f36a434a38875635e40e67cdad88bc85";
 
   // FIXME: used by js-load. should be moved
 BiwaScheme.require = function(src, check, proc){

--- a/test/unit.js
+++ b/test/unit.js
@@ -489,8 +489,12 @@ describe('11.5 Equivalence predicates', {
 
 describe('11.6 Procedure predicate' , {
   'procedure?' : function() {
-    ev("(procedure? (lambda ()))").should_be(true);
-    ev("(procedure? #(lambda ()))").should_be(false);
+    ev("(procedure? (lambda () 5))").should_be(true);
+    try {
+        ev("(procedure? (lambda ()))");
+        expect(this).should_fail("Invalid lambda syntax accepted");
+    } catch (e) { if(!(e instanceof BiwaScheme.Error)) throw e }
+    ev("(procedure? '(lambda ()))").should_be(false);
     ev("(procedure? car)").should_be(true);
     ev("(procedure? if)").should_be(false);
     ev("(procedure? define-macro)").should_be(false);
@@ -1515,7 +1519,7 @@ describe('browser functions', {
     BiwaScheme.TestForJSNew = function(obj){
       this.foo = obj["foo"];
     };
-    var tmp = scm_eval('(js-new "BiwaScheme.TestForJSNew" \'foo (lambda ()))');
+    var tmp = scm_eval('(js-new "BiwaScheme.TestForJSNew" \'foo (lambda () 4))');
     expect(Object.isFunction(tmp.foo)).should_be(true)
   },
   'js-null?' : function(){


### PR DESCRIPTION
I added some basic error-checking in the compile() function that checks the length of the S-exp for certain forms (define, if, lambda, etc.).  Updated a couple unit tests to reflect this.
