### PR TITLE
Cond without else always returns #<undef>

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -56,12 +56,15 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
           //  -> (begin expr ...)
           ret = new Pair(Sym("begin"), clause.cdr);
         }
-      } 
-      else if(ret === null){
-        // pattern D: no else clause
-        //  -> #<undef>
-        ret = BiwaScheme.undef;
       }
+      // The following made cond return <#undef> whenever there was no
+      // else clause, even if there was a true condition
+      //
+      // else if(ret === null){
+      //   // pattern D: no else clause
+      //   //  -> #<undef>
+      //   ret = BiwaScheme.undef;
+      // }
       else{
         var test = clause.car;
         if(clause.cdr === nil){


### PR DESCRIPTION
In the current version,

```
(let ((var 3))
  (cond ((= var 4) 1)
        ((= var 3) 2)))
```

returns `#<undef>`, even though there is a true condition, as will any `cond` with no `else`.  I've changed it so it will return `2`, as it should.
